### PR TITLE
Apply freeze by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ borschik
 * *String* **destTarget** — Результирующий таргет. Например, `_?.js`. Обязательная опция.
 * *String* **dependantFiles** — Замораживаемые борщиком файлы. Например `['?.css', '?.js']`.
 * *Boolean* **minify** — Минифицировать ли в процессе обработки. По умолчанию — `true`.
-* *Boolean* **freeze** — Использовать ли фризинг в процессе обработки. По умолчанию — `false`.
+* *Boolean* **freeze** — Использовать ли фризинг в процессе обработки. По умолчанию — `true`.
 * *String* **tech** — Технология сборки. По умолчанию — соответствует расширению исходного таргета.
 * *Object* **techOptions** — Параметры для технологии сборки. Возможные значения зависият от конкретной технологии.
 
@@ -33,7 +33,7 @@ nodeConfig.addTech([ require('enb-borschik/techs/borschik'), {
   sourceTarget: '?.css',
   destTarget: '_?.css',
   minify: true,
-  freeze: true,
+  freeze: false,
   tech: 'css+'
 } ]);
 ```
@@ -55,7 +55,7 @@ css-borschik-chunks
 * *String* **filesTarget** — files-таргет, на основе которого получается список исходных файлов
   (его предоставляет технология `files`). По умолчанию — `?.files`.
 * *Boolean* **minify** — Минифицировать ли в процессе обработки. По умолчанию — `true`.
-* *Boolean* **freeze** — Использовать ли фризинг в процессе обработки. По умолчанию — `false`.
+* *Boolean* **freeze** — Использовать ли фризинг в процессе обработки. По умолчанию — `true`.
 * *String* **tech** — Технология сборки. По умолчанию — соответствует расширению исходного таргета.
 
 **Пример**
@@ -63,7 +63,7 @@ css-borschik-chunks
 ```javascript
 nodeConfig.addTech([ require('enb-borschik/techs/css-borschik-chunks'), {
   minify: true,
-  freeze: true
+  freeze: false
 } ]);
 ```
 

--- a/techs/borschik.js
+++ b/techs/borschik.js
@@ -17,7 +17,7 @@ var path = require('path');
  * @param {String}      options.source             Path to a source file which should be processed.
  * @param {String[]}    [options.dependantFiles]   Files that must be built before borschik tech execution.
  * @param {Boolean}     [options.minify=true]      Minimize file during borschik processing.
- * @param {Boolean}     [options.freeze=false]     Freeze links to sources.
+ * @param {Boolean}     [options.freeze=true]      Freeze links to sources.
  * @param {Boolean}     [options.noCache=false]    Drops cache usage forcibly.
  * @param {String}      [options.tech]             Technology that should be processed with borschik.
  * @param {Object}      [options.techOptions]      Params for 'tech' option
@@ -46,7 +46,6 @@ var path = require('path');
  *             source: '?.css',
  *             target: '_?.css',
  *             tech: 'cleancss',
- *             freeze: true,
  *             minify: true
  *         }]);
  *         node.addTarget('_?.css');
@@ -62,7 +61,7 @@ module.exports = require('enb/lib/build-flow').create()
     .optionAlias('target', 'destTarget')
     .optionAlias('source', 'sourceTarget')
     .defineOption('minify', true)
-    .defineOption('freeze', false)
+    .defineOption('freeze', true)
     .defineOption('noCache', false)
     .defineOption('tech', null)
     .defineOption('techOptions', null)

--- a/techs/css-borschik-chunks.js
+++ b/techs/css-borschik-chunks.js
@@ -15,7 +15,7 @@
  * * *String* **filesTarget** — files-таргет, на основе которого получается список исходных файлов
  *   (его предоставляет технология `files`). По умолчанию — `?.files`.
  * * *Boolean* **minify** — Минифицировать ли в процессе обработки. По умолчанию — `true`.
- * * *Boolean* **freeze** — Использовать ли фризинг в процессе обработки. По умолчанию — `false`.
+ * * *Boolean* **freeze** — Использовать ли фризинг в процессе обработки. По умолчанию — `true`.
  * * *String* **tech** — Технология сборки. По умолчанию — соответствует расширению исходного таргета.
  *
  * **Пример**
@@ -23,7 +23,7 @@
  * ```javascript
  * nodeConfig.addTech([ require('enb-borschik/techs/css-borschik-chunks'), {
  *   minify: true,
- *   freeze: true
+ *   freeze: false
  * } ]);
  * ```
  */
@@ -34,7 +34,7 @@ module.exports = require('enb-bembundle/techs/css-chunks').buildFlow()
     .name('css-borschik-chunks')
     .deprecated('enb-borschik', 'enb-bembundle', 'css-borschik-chunks',
         'It will be removed from this package in the next major version')
-    .defineOption('freeze', false)
+    .defineOption('freeze', true)
     .defineOption('minify', false)
     .defineOption('tech', null)
     .methods({


### PR DESCRIPTION
The reason to apply `freeze` by default is that without `.borschik` config in the project folder no freezing will be applied anyway. And in case there is such config it's obvious that user want freeze to be turned on.