### PR TITLE
Всегда пробрасывать techOptions

### DIFF
--- a/lib/borschik-preprocessor.js
+++ b/lib/borschik-preprocessor.js
@@ -29,13 +29,11 @@ module.exports = inherit({
             output: destFilename,
             freeze: freeze,
             minimize: minimize,
-            comments: comments
+            comments: comments,
+            techOptions: techOptions
         };
         if (tech) {
             opts.tech = tech;
-            if (techOptions) {
-                opts.techOptions = techOptions;
-            }
         }
         return vow.when(borschik.api(opts));
     }


### PR DESCRIPTION
В текущей ситуации можно долго разбираться, почему же Uglify не получил параметры для сборки, например.